### PR TITLE
Fix sprite transparency bug and ignore pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 cache
 venv
+__pycache__/
+

--- a/game.py
+++ b/game.py
@@ -126,13 +126,12 @@ def generate_sprite(prompt, cache_path, game=None):
         # Resize to 32x32 while maintaining pixel art style
         img = img.resize((32, 32), Image.Resampling.NEAREST)
         
-        # Make white/light backgrounds transparent
-        # Convert very light pixels to transparent
+        # Convert dark background pixels to transparent
         data = img.getdata()
         new_data = []
         for item in data:
             # If pixel is very dark (close to black), make it transparent
-            if item[0] + item[1] + item[3] < 30:
+            if item[0] + item[1] + item[2] < 30:
                 new_data.append((255, 255, 255, 0))  # Transparent
             else:
                 new_data.append(item)


### PR DESCRIPTION
## Summary
- corrected color channel check when replacing dark pixels with transparency
- add `__pycache__/` to `.gitignore`

## Testing
- `python -m py_compile dungeon_crawler.py game.py`


------
https://chatgpt.com/codex/tasks/task_e_684b216eb6648332adadad8714026a3f